### PR TITLE
Add layers building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+spec/tmp/*
+!spec/tmp/.keep

--- a/README.md
+++ b/README.md
@@ -46,12 +46,22 @@ lambda_ruby_bundler \
   --out /tmp/build.zip
 ```
 
-It will produce a ZIP file with the following files:
+It will produce two ZIP files, one with the contents of the application directory:
 
 ```
+# build.zip
 ├ handler.rb
-├ vendor/bundle/...
 ```
+
+And one with bundled dependencies:
+
+```
+# build-dependencies.zip
+ruby/gems/2.5.0
+├── gems/...
+```
+
+The first one is meant as the Lambda code, while second will work as Lambda Layer, allowing you to share it between multiple Lambdas using the same codebase.
 
 Note that:
 
@@ -64,10 +74,13 @@ Note that:
 ```ruby
 executor = LambdaRubyBundler::Executor.new(
   '/tmp/my_serverless_app',
-  'backend'
+  'backend',
+  true
 )
 
-File.write('bundle.zip', executor.run.read)
+result = executor.run
+File.write('bundle.zip', result[:application_bundle].read)
+File.write('dependencies.zip', result[:dependency_layer].read)
 ```
 
 ### Ruby versions

--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ File.write('bundle.zip', result[:application_bundle].read)
 File.write('dependencies.zip', result[:dependency_layer].read)
 ```
 
+### Cache mode
+
+The gem can also automatically assign build paths and cache them. To use Cache Mode, simply use `--cache-dir` option in CLI usage or use `LambdaRubyBundler::CLI::CacheRunner` class to generate the bundles.
+
+```bash
+lambda_ruby_bundler --app-path backend --cache-dir tmp
+```
+
+```ruby
+runner = LambdaRubyBundler::CLI::CacheRunner.new(Dir.pwd, 'backend', 'tmp')
+runner.run
+```
+
+This will save the bundles in cache directory and will output the paths to STDOUT (CLI case) or return them as Hash (programmatic usage).
+
 ### Ruby versions
 
 Currently, Lambda supports only Ruby 2.5 environment - specifically, `2.5.5`. At the moment of writing this Readme, newest version from `2.5.x` family is `2.5.7`.

--- a/exe/lambda_ruby_bundler
+++ b/exe/lambda_ruby_bundler
@@ -6,11 +6,15 @@ require 'lambda_ruby_bundler/cli/option_parser'
 
 options = LambdaRubyBundler::CLI::OptionParser.new.parse!(ARGV)
 executor = LambdaRubyBundler::Executor.new(
-  options[:root_path], options[:app_path]
+  options[:root_path], options[:app_path], options[:build_dependencies]
 )
 
 result = executor.run
 
 File.open(options[:output_path], 'wb+') do |file|
-  file.write(result.read)
+  file.write(result[:application_bundle].read)
+end
+
+File.open(options[:dependencies_path], 'wb+') do |file|
+  file.write(result[:dependency_layer].read)
 end

--- a/exe/lambda_ruby_bundler
+++ b/exe/lambda_ruby_bundler
@@ -2,19 +2,21 @@
 # frozen_string_literal: true
 
 require 'lambda_ruby_bundler'
-require 'lambda_ruby_bundler/cli/option_parser'
 
 options = LambdaRubyBundler::CLI::OptionParser.new.parse!(ARGV)
-executor = LambdaRubyBundler::Executor.new(
-  options[:root_path], options[:app_path], options[:build_dependencies]
-)
 
-result = executor.run
+runner = if options[:cache_dir]
+           LambdaRubyBundler::CLI::CacheRunner.new(
+             options[:root_path], options[:app_path], options[:cache_dir]
+           )
+         else
+           LambdaRubyBundler::CLI::StandardRunner.new(
+             options[:root_path],
+             options[:app_path],
+             options[:build_dependencies],
+             application_bundle: options[:output_path],
+             dependency_layer: options[:dependencies_path]
+           )
+         end
 
-File.open(options[:output_path], 'wb+') do |file|
-  file.write(result[:application_bundle].read)
-end
-
-File.open(options[:dependencies_path], 'wb+') do |file|
-  file.write(result[:dependency_layer].read)
-end
+puts runner.run.to_json

--- a/lib/lambda_ruby_bundler.rb
+++ b/lib/lambda_ruby_bundler.rb
@@ -2,14 +2,23 @@
 
 require 'lambda_ruby_bundler/version'
 
+require 'digest'
 require 'docker'
 require 'forwardable'
+require 'optparse'
+require 'json'
 require 'singleton'
 
 require 'lambda_ruby_bundler/image'
 require 'lambda_ruby_bundler/volume'
 require 'lambda_ruby_bundler/container'
 require 'lambda_ruby_bundler/executor'
+
+require 'lambda_ruby_bundler/cli'
+require 'lambda_ruby_bundler/cli/option_parser'
+require 'lambda_ruby_bundler/cli/base_runner'
+require 'lambda_ruby_bundler/cli/cache_runner'
+require 'lambda_ruby_bundler/cli/standard_runner'
 
 module LambdaRubyBundler
   class Error < StandardError; end

--- a/lib/lambda_ruby_bundler/cli.rb
+++ b/lib/lambda_ruby_bundler/cli.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module LambdaRubyBundler
+  # Namespace for handling Command Line Interface
+  module CLI
+  end
+end

--- a/lib/lambda_ruby_bundler/cli/base_runner.rb
+++ b/lib/lambda_ruby_bundler/cli/base_runner.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module LambdaRubyBundler
+  module CLI
+    # Runs the executor.
+    # @api private
+    class BaseRunner
+      attr_reader :root_path, :app_path
+
+      def initialize(root_path, app_path)
+        @root_path = root_path
+        @app_path = app_path
+      end
+
+      private
+
+      def bundle(build_dependencies)
+        executor = LambdaRubyBundler::Executor.new(
+          root_path, app_path, build_dependencies
+        )
+
+        result = executor.run
+
+        save(result[:application_bundle], paths[:application_bundle])
+        return unless build_dependencies
+
+        save(result[:dependency_layer], paths[:dependency_layer])
+      end
+
+      def save(io, path)
+        File.open(path, 'wb+') { |file| file.write(io.read) }
+      end
+    end
+  end
+end

--- a/lib/lambda_ruby_bundler/cli/cache_runner.rb
+++ b/lib/lambda_ruby_bundler/cli/cache_runner.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+require 'lambda_ruby_bundler/executor'
+
+module LambdaRubyBundler
+  module CLI
+    # Runs the executor in Cache Mode.
+    class CacheRunner
+      MD5_EXTRACT_REGEX = /build(?:dep)?-([a-f0-9]{32}).zip/.freeze
+
+      attr_reader :root_path, :app_path, :cache_dir
+
+      # Creates new instance of cache runner.
+      #
+      # @param [String] root_path
+      #   Path to the root of application (containing Gemfile.lock)
+      # @param [String] app_path
+      #   Path (relative to root_path) containing application code
+      # @param [String]
+      #   cache_dir Directory containing cached builds
+      def initialize(root_path, app_path, cache_dir)
+        @root_path = root_path
+        @app_path = app_path
+        @cache_dir = cache_dir
+      end
+
+      # Runs the executor, if necessary. Returns hash with two keys:
+      #   :application_bundle => path to the application code bundle
+      #   :dependency_layer => path to dependency bundle
+      #
+      # @return [Hash] Paths to the builds
+      def run
+        build_dependencies = !dependencies_builds.key?(dependencies_hash)
+        build_application = !application_builds.key?(application_hash)
+
+        if build_application || build_dependencies
+          clear_cache
+          bundle(build_dependencies)
+        end
+
+        paths
+      end
+
+      private
+
+      def clear_cache
+        (application_builds.values + dependencies_builds.values).each do |file|
+          FileUtils.rm(file)
+        end
+      end
+
+      def bundle(build_dependencies)
+        executor = LambdaRubyBundler::Executor.new(
+          root_path, app_path, build_dependencies
+        )
+
+        result = executor.run
+
+        save(result[:application_bundle], paths[:application_bundle])
+        return unless build_dependencies
+
+        save(result[:dependency_layer], paths[:dependency_layer])
+      end
+
+      def save(io, path)
+        File.open(path, 'wb+') { |file| file.write(io.read) }
+      end
+
+      def paths
+        @paths ||= {
+          application_bundle:
+            File.join(cache_dir, "build-#{application_hash}.zip"),
+          dependency_layer:
+            File.join(cache_dir, "builddep-#{dependencies_hash}.zip")
+        }
+      end
+
+      def application_hash
+        @application_hash ||= begin
+          files = Dir[File.join(root_path, app_path, '**', '*')]
+          digest = Digest::MD5.new
+
+          files.each { |file| digest << File.read(file) }
+
+          digest.hexdigest
+        end
+      end
+
+      def dependencies_hash
+        @dependencies_hash ||= begin
+          path = File.join(root_path, 'Gemfile.lock')
+          content = File.read(path)
+          Digest::MD5.hexdigest(content)
+        end
+      end
+
+      def application_builds
+        @application_builds ||= fetch_builds('build-*.zip')
+      end
+
+      def dependencies_builds
+        @dependencies_builds ||= fetch_builds('builddep-*.zip')
+      end
+
+      def fetch_builds(name_glob)
+        Dir[File.join(cache_dir, name_glob)]
+          .group_by(&method(:extract_md5))
+          .transform_values(&:first)
+          .tap { |result| result.delete(nil) }
+      end
+
+      def extract_md5(path)
+        MD5_EXTRACT_REGEX.match(path)&.captures&.at(0)
+      end
+    end
+  end
+end

--- a/lib/lambda_ruby_bundler/cli/option_parser.rb
+++ b/lib/lambda_ruby_bundler/cli/option_parser.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'optparse'
-
 module LambdaRubyBundler
   module CLI
     # Custom OptionParser which collects user-supplied options about the build.

--- a/lib/lambda_ruby_bundler/cli/option_parser.rb
+++ b/lib/lambda_ruby_bundler/cli/option_parser.rb
@@ -15,6 +15,7 @@ module LambdaRubyBundler
         output_option
         no_dependencies_option
         dependencies_path_option
+        cache_dir_option
       ].freeze
 
       def initialize
@@ -41,7 +42,8 @@ module LambdaRubyBundler
           app_path: '.',
           build_dependencies: true,
           dependencies_path: nil,
-          output_path: 'build.zip'
+          output_path: 'build.zip',
+          cache_dir: nil
         }
       end
 
@@ -94,6 +96,15 @@ module LambdaRubyBundler
           'Sets path for the dependencies layer package (defaults to ' \
           '{OUT_PATH}-dependencies.zip)',
           &assign_option(:dependencies_path)
+        )
+      end
+
+      def cache_dir_option(builder)
+        builder.on(
+          '--cache-dir=CACHE_DIR',
+          'Enables Cache Mode and uses chosen directory as target directory ' \
+          'for the builds.',
+          &assign_option(:cache_dir)
         )
       end
 

--- a/lib/lambda_ruby_bundler/cli/standard_runner.rb
+++ b/lib/lambda_ruby_bundler/cli/standard_runner.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module LambdaRubyBundler
+  module CLI
+    # Runs the executor with given parameters.
+    class StandardRunner < BaseRunner
+      attr_reader :build_dependencies, :paths
+
+      # Creates new instance of cache runner.
+      #
+      # @param [String] root_path
+      #   Path to the root of application (containing Gemfile.lock)
+      # @param [String] app_path
+      #   Path (relative to root_path) containing application code
+      # @param [Boolean] build_dependencies
+      #   Whether or not to build dependencies
+      # @param [Hash] paths
+      #   Hash with :application_bundle and :dependency_layer output paths
+      def initialize(root_path, app_path, build_dependencies, paths)
+        super(root_path, app_path)
+        @build_dependencies = build_dependencies
+        @paths = paths
+      end
+
+      # Runs the executo. Returns hash with two keys:
+      #   :application_bundle => path to the application code bundle
+      #   :dependency_layer => path to dependency bundle
+      #
+      # @return [Hash] Paths to the builds
+      def run
+        bundle(build_dependencies)
+      end
+    end
+  end
+end

--- a/lib/lambda_ruby_bundler/container.rb
+++ b/lib/lambda_ruby_bundler/container.rb
@@ -5,12 +5,13 @@ module LambdaRubyBundler
   # bundler containers.
   # @api private
   class Container
-    attr_reader :root_path, :app_path, :volume
+    attr_reader :root_path, :app_path, :volume, :build_dependencies
 
-    def initialize(root_path, app_path, volume)
+    def initialize(root_path, app_path, volume, build_dependencies)
       @root_path = root_path
       @app_path = app_path
       @volume = volume
+      @build_dependencies = build_dependencies
     end
 
     def run(timeout: 120)
@@ -31,7 +32,7 @@ module LambdaRubyBundler
     end
 
     def container_arguments
-      { 'Cmd' => [app_path],
+      { 'Cmd' => [app_path, build_dependencies ? 'use-deps' : 'no-deps'],
         'Image' => Image.instance.id,
         'HostConfig' => {
           'AutoRemove' => true,

--- a/lib/lambda_ruby_bundler/executor.rb
+++ b/lib/lambda_ruby_bundler/executor.rb
@@ -46,8 +46,9 @@ module LambdaRubyBundler
     # @return [StringIO] IO containing contents of the ZIP
     def run
       zipped_contents, = container.run.tap { container.destroy }
+      contents = JSON.parse(zipped_contents.join)
 
-      StringIO.new(zipped_contents.join)
+      StringIO.new(Base64.strict_decode64(contents['application_bundle']))
     end
 
     private

--- a/lib/lambda_ruby_bundler/executor.rb
+++ b/lib/lambda_ruby_bundler/executor.rb
@@ -19,16 +19,19 @@ module LambdaRubyBundler
   #
   #     executor = LambdaRubyBundler::Executor.new(
   #       '/tmp/my_serverless_app',
-  #       'backend'
+  #       'backend',
+  #       true
   #     )
   #
-  #     File.write('bundle.zip', executor.run.read)
+  #     result = executor.run
+  #     File.write('bundle.zip', result[:application_bundle].read)
+  #     File.write('dependencies.zip', result[:dependency_layer].read)
   #
   #     # Note that resulting structure of the ZIP will be flattened!
   #     # + handler.rb
   #     # + vendor/bundle/...
   class Executor
-    attr_reader :root_path, :app_path
+    attr_reader :root_path, :app_path, :build_dependencies
 
     # Creates new instance of the Executor.
     #
@@ -36,29 +39,44 @@ module LambdaRubyBundler
     #   Path to the root of the application (with Gemfile)
     # @param [String] app_path
     #   Path to the Ruby application code, relative to root.
-    def initialize(root_path, app_path)
+    # @param [Boolean] build_dependencies
+    #   Flag whether or not to bundle the dependencies.
+    #   Useful in cases when dependencies (Gemfile.lock) does not change
+    #   between builds.
+    def initialize(root_path, app_path, build_dependencies)
       @root_path = root_path
       @app_path = app_path
+      @build_dependencies = build_dependencies
     end
 
     # Generates the ZIP contents.
     #
-    # @return [StringIO] IO containing contents of the ZIP
+    # @return [Hash{:application_bundle, :dependency_layer => StringIO}]
+    #   Hash with the zip IOs. If `build_dependencies` options was falsey,
+    #   There will be no :dependency_layer key.
     def run
       zipped_contents, = container.run.tap { container.destroy }
       contents = JSON.parse(zipped_contents.join)
 
-      StringIO.new(Base64.strict_decode64(contents['application_bundle']))
+      decode(contents)
     end
 
     private
+
+    def decode(contents)
+      contents.each_with_object({}) do |(key, data), result|
+        result[key.to_sym] = StringIO.new(Base64.strict_decode64(data))
+      end
+    end
 
     def application_name
       @application_name ||= File.basename(root_path)
     end
 
     def container
-      @container ||= Container.new(root_path, app_path, volume)
+      @container ||= Container.new(
+        root_path, app_path, volume, build_dependencies
+      )
     end
 
     def volume

--- a/lib/lambda_ruby_bundler/packager.rb
+++ b/lib/lambda_ruby_bundler/packager.rb
@@ -45,8 +45,15 @@ if BUNDLE_DEPS
   # Clean unused gems
   silent('bundle clean')
 
+  # Create proper structure for AWS Layer
+  FileUtils.mkdir_p('/tmp/layer/ruby/gems')
+  FileUtils.symlink(
+    '/workspace/build/vendor/bundle/ruby/2.5.0',
+    '/tmp/layer/ruby/gems/2.5.0'
+  )
+
   # Zip the dependencies
-  silent('cd /workspace/build/vendor/bundle && zip -r /tmp/dependencies.zip .')
+  silent('cd /tmp/layer && zip -r /tmp/dependencies.zip .')
 
   # Add serialized ZIP to result
   content = File.read('/tmp/dependencies.zip')

--- a/lib/lambda_ruby_bundler/packager.rb
+++ b/lib/lambda_ruby_bundler/packager.rb
@@ -5,6 +5,7 @@
 
 require 'fileutils'
 require 'json'
+require 'base64'
 
 APPLICATION_DIRECTORY, = ARGV
 
@@ -47,4 +48,7 @@ FileUtils.cp_r(contents, '/workspace/build')
 # Zip the contents and print
 silent('cd /workspace/build && zip -r /tmp/out.zip .')
 
-exec('cat /tmp/out.zip')
+# Read and serialize the resulting ZIP
+serialized_app_bundle = Base64.strict_encode64(File.read('/tmp/out.zip'))
+
+puts({ application_bundle: serialized_app_bundle }.to_json)

--- a/lib/lambda_ruby_bundler/packager.rb
+++ b/lib/lambda_ruby_bundler/packager.rb
@@ -8,6 +8,7 @@ require 'json'
 require 'base64'
 
 APPLICATION_DIRECTORY, = ARGV
+BUNDLE_DEPS = ARGV.include?('use-deps')
 
 def silent(command)
   system(command, out: File::NULL, err: File::NULL)
@@ -23,32 +24,41 @@ end
 
 RUBY_ENTRY_REGEX = /\A\s*ruby\s+("|')\d+\.\d+\.\d+("|')\s*\z/.freeze
 
-# Copy Gemfile and Gemfile.lock to the workspace
-FileUtils.cp('/app/Gemfile', '/workspace/Gemfile')
-FileUtils.cp('/app/Gemfile.lock', '/workspace/Gemfile.lock')
+result = {}
 
-# Clean Ruby version requirement from Gemfile
-contents = File.read('/workspace/Gemfile').lines
-contents.reject! { |line| RUBY_ENTRY_REGEX.match(line) }
-File.write('/workspace/Gemfile', contents.join)
+if BUNDLE_DEPS
+  # Copy Gemfile and Gemfile.lock to the workspace
+  FileUtils.cp('/app/Gemfile', '/workspace/Gemfile')
+  FileUtils.cp('/app/Gemfile.lock', '/workspace/Gemfile.lock')
 
-# Check if all gems are installed
-all_installed = silent(bundle_install('--local'))
+  # Clean Ruby version requirement from Gemfile
+  contents = File.read('/workspace/Gemfile').lines
+  contents.reject! { |line| RUBY_ENTRY_REGEX.match(line) }
+  File.write('/workspace/Gemfile', contents.join)
 
-# Install if some gems are missing locally
-silent(bundle_install) unless all_installed
+  # Check if all gems are installed
+  all_installed = silent(bundle_install('--local'))
 
-# Clean unused gems
-silent('bundle clean')
+  # Install if some gems are missing locally
+  silent(bundle_install) unless all_installed
 
-# Copy application directory contents
-contents = File.join('/app', APPLICATION_DIRECTORY, '.')
-FileUtils.cp_r(contents, '/workspace/build')
+  # Clean unused gems
+  silent('bundle clean')
 
-# Zip the contents and print
-silent('cd /workspace/build && zip -r /tmp/out.zip .')
+  # Zip the dependencies
+  silent('cd /workspace/build/vendor/bundle && zip -r /tmp/dependencies.zip .')
 
-# Read and serialize the resulting ZIP
-serialized_app_bundle = Base64.strict_encode64(File.read('/tmp/out.zip'))
+  # Add serialized ZIP to result
+  content = File.read('/tmp/dependencies.zip')
+  result[:dependency_layer] = Base64.strict_encode64(content)
+end
 
-puts({ application_bundle: serialized_app_bundle }.to_json)
+# Zip the application code
+app_path = File.join('/app', APPLICATION_DIRECTORY)
+silent("cd #{app_path} && zip -r /tmp/app.zip .")
+
+# Add serialized ZIP to result
+content = File.read('/tmp/app.zip')
+result[:application_bundle] = Base64.strict_encode64(content)
+
+puts(result.to_json)

--- a/spec/lambda_ruby_bundler/cli/cache_runner_spec.rb
+++ b/spec/lambda_ruby_bundler/cli/cache_runner_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'lambda_ruby_bundler/cli/cache_runner'
-
 RSpec.describe LambdaRubyBundler::CLI::CacheRunner do
   include_context 'with application', :regular_dep
 
@@ -24,7 +22,7 @@ RSpec.describe LambdaRubyBundler::CLI::CacheRunner do
       it 'creates two bundles' do
         expect { run }
           .to change { Dir.chdir(cache_dir) { Dir['*.zip'] } }
-          .to expected_files
+          .to match_array(expected_files)
       end
     end
 

--- a/spec/lambda_ruby_bundler/cli/cache_runner_spec.rb
+++ b/spec/lambda_ruby_bundler/cli/cache_runner_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'lambda_ruby_bundler/cli/cache_runner'
+
+RSpec.describe LambdaRubyBundler::CLI::CacheRunner do
+  include_context 'with application', :regular_dep
+
+  let(:cache_dir) { File.expand_path('../../tmp', __dir__) }
+  let(:cache_runner) { described_class.new(root_path, app_path, cache_dir) }
+
+  describe '#run' do
+    subject(:run) { cache_runner.run }
+
+    after do
+      Dir.chdir(cache_dir) { Dir['*.zip'].each { |file| FileUtils.rm(file) } }
+    end
+
+    context 'when no files are cached' do
+      let(:expected_files) do
+        %w[build-ea0bee47006f367bed582487677373f7.zip
+           builddep-8039ff1e0a67a903637112f513333448.zip]
+      end
+
+      it 'creates two bundles' do
+        expect { run }
+          .to change { Dir.chdir(cache_dir) { Dir['*.zip'] } }
+          .to expected_files
+      end
+    end
+
+    context 'when there are cached builds' do
+      let(:valid_application_hash) { 'ea0bee47006f367bed582487677373f7' }
+      let(:valid_dependency_hash) { '8039ff1e0a67a903637112f513333448' }
+
+      let(:cached_application_hash) { valid_application_hash }
+      let(:cached_dependency_hash) { valid_dependency_hash }
+
+      let(:cached_application_path) do
+        File.join(cache_dir, "build-#{cached_application_hash}.zip")
+      end
+
+      let(:cached_dependency_path) do
+        File.join(cache_dir, "builddep-#{cached_dependency_hash}.zip")
+      end
+
+      before do
+        File.write(cached_application_path, '1')
+        File.write(cached_dependency_path, '2')
+
+        allow(LambdaRubyBundler::Executor).to receive(:new).and_call_original
+      end
+
+      context 'with expired application code' do
+        let(:cached_application_hash) { valid_application_hash.reverse }
+
+        it 'does not build dependencies' do
+          run
+
+          expect(LambdaRubyBundler::Executor)
+            .to have_received(:new).with(root_path, app_path, false)
+        end
+
+        it 'removes old bundle' do
+          expect { run }
+            .to change { File.exist?(cached_application_path) }
+            .to(false)
+        end
+      end
+
+      context 'when no builds are expired' do
+        it 'does not run executor' do
+          run
+
+          expect(LambdaRubyBundler::Executor).not_to have_received(:new)
+        end
+      end
+    end
+  end
+end

--- a/spec/lambda_ruby_bundler/cli/options_parser_spec.rb
+++ b/spec/lambda_ruby_bundler/cli/options_parser_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe LambdaRubyBundler::CLI::OptionParser do
           app_path: '.',
           output_path: 'build.zip',
           build_dependencies: true,
-          dependencies_path: './build-dependencies.zip'
+          dependencies_path: './build-dependencies.zip',
+          cache_dir: nil
         }
       end
 
@@ -35,7 +36,9 @@ RSpec.describe LambdaRubyBundler::CLI::OptionParser do
           '/tmp/build.zip',
           '--no-dependencies',
           '--dependencies-path',
-          '/tmp/deps.zip'
+          '/tmp/deps.zip',
+          '--cache_dir',
+          'tmp'
         ]
       end
 
@@ -45,7 +48,8 @@ RSpec.describe LambdaRubyBundler::CLI::OptionParser do
           app_path: 'code',
           output_path: '/tmp/build.zip',
           build_dependencies: false,
-          dependencies_path: '/tmp/deps.zip'
+          dependencies_path: '/tmp/deps.zip',
+          cache_dir: 'tmp'
         }
       end
 

--- a/spec/lambda_ruby_bundler/cli/options_parser_spec.rb
+++ b/spec/lambda_ruby_bundler/cli/options_parser_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'lambda_ruby_bundler/cli/option_parser'
-
 RSpec.describe LambdaRubyBundler::CLI::OptionParser do
   let(:options_parser) { described_class.new }
 

--- a/spec/lambda_ruby_bundler/cli/options_spec.rb
+++ b/spec/lambda_ruby_bundler/cli/options_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe LambdaRubyBundler::CLI::OptionParser do
         {
           root_path: Dir.pwd,
           app_path: '.',
-          output_path: 'build.zip'
+          output_path: 'build.zip',
+          build_dependencies: true,
+          dependencies_path: './build-dependencies.zip'
         }
       end
 
@@ -30,7 +32,10 @@ RSpec.describe LambdaRubyBundler::CLI::OptionParser do
           '--app-path',
           'code',
           '--out',
-          '/tmp/build.zip'
+          '/tmp/build.zip',
+          '--no-dependencies',
+          '--dependencies-path',
+          '/tmp/deps.zip'
         ]
       end
 
@@ -38,7 +43,9 @@ RSpec.describe LambdaRubyBundler::CLI::OptionParser do
         {
           root_path: File.join(Dir.pwd, 'app'),
           app_path: 'code',
-          output_path: '/tmp/build.zip'
+          output_path: '/tmp/build.zip',
+          build_dependencies: false,
+          dependencies_path: '/tmp/deps.zip'
         }
       end
 

--- a/spec/lambda_ruby_bundler/cli/standard_runner_spec.rb
+++ b/spec/lambda_ruby_bundler/cli/standard_runner_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe LambdaRubyBundler::CLI::StandardRunner do
+  include_context 'with application', :regular_dep
+
+  let(:tmp_dir) { File.expand_path('../../tmp', __dir__) }
+  let(:runner) { described_class.new(root_path, app_path, false, paths) }
+
+  let(:paths) do
+    {
+      application_bundle: File.join(tmp_dir, 'build.zip'),
+      dependency_layer: File.join(tmp_dir, 'deps.zip')
+    }
+  end
+
+  describe '#run' do
+    subject(:run) { runner.run }
+
+    let(:expected_files) { %w[build.zip] }
+
+    after do
+      Dir.chdir(tmp_dir) { Dir['*.zip'].each { |file| FileUtils.rm(file) } }
+    end
+
+    it 'creates requested bundles' do
+      expect { run }
+        .to change { Dir.chdir(tmp_dir) { Dir['*.zip'] } }
+        .to expected_files
+    end
+  end
+end

--- a/spec/lambda_ruby_bundler/executor_spec.rb
+++ b/spec/lambda_ruby_bundler/executor_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe LambdaRubyBundler::Executor do
       include_context 'with application', :regular_dep
 
       it_behaves_like 'application bundler',
-                      %w[default_handler.rb], [%r{gems/rake-13.0.0}]
+                      %w[default_handler.rb],
+                      [%r{ruby/gems/2\.5\.0/gems/rake-13.0.0}]
     end
 
     context 'when application has dependency with native extensions' do
@@ -47,7 +48,8 @@ RSpec.describe LambdaRubyBundler::Executor do
       end
 
       it_behaves_like 'application bundler',
-                      %w[default_handler.rb], [%r{gems/jaro_winkler-1.5.4}]
+                      %w[default_handler.rb],
+                      [%r{ruby/gems/2\.5\.0/gems/jaro_winkler-1.5.4}]
 
       it 'builds extension' do
         expect(dependency_layer_entries)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'lambda_ruby_bundler'
 require 'zip'
 
 require 'support/shared_contexts/application'
+require 'support/shared_examples/application_bundler'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/shared_contexts/application.rb
+++ b/spec/support/shared_contexts/application.rb
@@ -14,7 +14,9 @@ RSpec.shared_context 'with application' do |application_name|
     File.expand_path(File.join('..', 'apps', application_name.to_s), __dir__)
   end
 
-  let(:executor) { LambdaRubyBundler::Executor.new(root_path, app_path) }
+  let(:executor) do
+    LambdaRubyBundler::Executor.new(root_path, app_path, build_dependencies)
+  end
 
   after do
     executor.send(:volume).send(:volume).remove

--- a/spec/support/shared_contexts/application.rb
+++ b/spec/support/shared_contexts/application.rb
@@ -14,6 +14,8 @@ RSpec.shared_context 'with application' do |application_name|
     File.expand_path(File.join('..', 'apps', application_name.to_s), __dir__)
   end
 
+  let(:build_dependencies) { true }
+
   let(:executor) do
     LambdaRubyBundler::Executor.new(root_path, app_path, build_dependencies)
   end

--- a/spec/support/shared_examples/application_bundler.rb
+++ b/spec/support/shared_examples/application_bundler.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for 'application bundler' do |application_files, gems|
+  it 'contains application files' do
+    expect(application_bundle_entries).to include(*application_files)
+  end
+
+  it 'does not bundle any gems in application bundle' do
+    expect(application_bundle_entries).to_not include match(/gems/)
+  end
+
+  if gems.any?
+    let(:gem_matchers) { gems.map { |gem| match(gem) } }
+
+    it 'bundles gems in dependency layer' do
+      expect(dependency_layer_entries).to include(*gem_matchers)
+    end
+  end
+
+  context 'when dependency bundling is disabled' do
+    let(:build_dependencies) { false }
+
+    it 'contains application files' do
+      expect(application_bundle_entries).to include(*application_files)
+    end
+
+    it 'does not include dependency layer' do
+      expect(run).not_to have_key(:dependency_layer)
+    end
+  end
+end


### PR DESCRIPTION
* splits the bundle into dependency layer and application code
* adds cache mode which lifts the need to specify paths manually, relying instead on the naming convention and files present in the cache directory